### PR TITLE
add optional basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Please Note: You can configure the following keys:
 - package_prefixes: package-prefixes, which should be searched for to be cleaned out
 - save_last_pkg: Number of package-versions for each prefix, that should be kept
 - save_last_snap: Number of snapshot-versions for each prefix, that should be kept
+- repos: 3rd party s3 buckets to publish switch to
+- staging_snap_pre_post: Pre and postfix of the staging snapshots
+- auth: user to authenticate using basic auth
+- password: password to authenticate using basic auth
 
 See an working example (aptly-cli.conf):
 
@@ -118,6 +122,10 @@ save_last_snap=3
 repos=3rdparty-eu-west-1, 3rdparty-us-east-1
 # Pre and postfix of the staging snapshots
 staging_snap_pre_post=3rdparty-s3-repo, 3rdparty-staging_snapshot
+
+[auth]
+user=jenkins
+password=
 ```
 
 

--- a/aptly_cli/cli/cli.py
+++ b/aptly_cli/cli/cli.py
@@ -36,6 +36,12 @@ def _get_parser_opts():
     """
     parser = OptionParser()
 
+    parser.add_option('--username',
+                      nargs=1,
+                      default=None,
+                      help='Username to auth on aptly',
+                      metavar='USERNAME')
+
     parser.add_option('--repo_list',
                       action='store_true',
                       help='List all local repos')
@@ -228,9 +234,12 @@ def _execute_opts(opts, args, util):
         """
         def __init__(self):
             pass
+
     #
     # Basic API functionalities
     #
+    util.api.update_auth(opts.username)
+
     if opts.repo_list:
         resp = util.api.repo_list()
         print json.dumps(resp, indent=2)

--- a/aptly_cli/util/util.py
+++ b/aptly_cli/util/util.py
@@ -44,8 +44,10 @@ class Util(object):
             try:
                 conf = open(name, 'a')
                 conf.write(
-                    '[general]\nbasic_url=http://localhost\nport=:9003\nsave_last_snap=3\nsave_last_pkg=10\n \
-prefixes_mirrors=\npackage_prefixes=\nrepos_to_clean=\n[general]\nrepos=\nstaging_snap_pre_post=')
+                    '[general]\nbasic_url=http://localhost\nport=:9003\n \
+                    save_last_snap=3\nsave_last_pkg=10\nprefixes_mirrors=\n \
+                    package_prefixes=\nrepos_to_clean=\n[3rd_party]\nrepos=\n \
+                    staging_snap_pre_post=\n[auth]\user=\npassword=\n')
                 conf.close()
 
             except:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+aptly-cli (0.1.9) UNRELEASED; urgency=medium
+
+  * Add basic auth
+
+ -- Jenkins <jenkins@static.88-198-43-17.clients.your-server.de>  Wed, 09 Aug 2017 20:20:18 +0200
+
 aptly-cli (0.1.8-c4efef0ac0263ac3c8b55357f684aa01cf71e727-unstable) UNRELEASED; urgency=low
 
   * Initial release. (Closes: #XXXXXX)

--- a/etc/aptly-cli.conf
+++ b/etc/aptly-cli.conf
@@ -13,3 +13,7 @@ save_last_snap=3
 repos=3rdparty-eu-west-1, 3rdparty-us-east-1
 # Pre and postfix of the staging snapshots
 staging_snap_pre_post=3rdparty-s3-repo, 3rdparty-staging_snapshot
+
+[auth]
+username=jenkins
+password=


### PR DESCRIPTION
Hi, I really love the cli, but i need to use basic auth on the requests, so here is a PR to allow optional basic auth from cli and config file.

I used session requests so it comes easier to modify parameters that are being used on every request, i.e if someone needs to add another optional auth type on the future, just change it on the session.

WDYT?